### PR TITLE
FalconHIDButtonBuilder change() method returns this

### DIFF
--- a/wpi/src/main/kotlin/org/ghrobotics/lib/wrappers/hid/FalconHID.kt
+++ b/wpi/src/main/kotlin/org/ghrobotics/lib/wrappers/hid/FalconHID.kt
@@ -88,9 +88,10 @@ class FalconHIDButtonBuilder(source: HIDSource, private val threshold: Double) :
     private val changeOn = mutableListOf<HIDControlListener>()
     private val changeOff = mutableListOf<HIDControlListener>()
 
-    fun change(command: Command) {
+    fun change(command: Command): FalconHIDButtonBuilder {
         changeOn(command)
         changeOff { command.cancel() }
+        return this
     }
 
     fun changeOn(command: Command) = changeOn { command.schedule() }


### PR DESCRIPTION
Previously, the change() method of the button builder didn't return `this`, while other change methods did. This commit addresses this.