### PR TITLE
Add FalconTrajectoryConfig method overrides to chain constraint adds

### DIFF
--- a/core/src/main/kotlin/org/ghrobotics/lib/mathematics/twodim/trajectory/FalconTrajectoryConfig.kt
+++ b/core/src/main/kotlin/org/ghrobotics/lib/mathematics/twodim/trajectory/FalconTrajectoryConfig.kt
@@ -9,6 +9,7 @@
 package org.ghrobotics.lib.mathematics.twodim.trajectory
 
 import edu.wpi.first.wpilibj.trajectory.TrajectoryConfig
+import edu.wpi.first.wpilibj.trajectory.constraint.TrajectoryConstraint
 import org.ghrobotics.lib.mathematics.units.SIUnit
 import org.ghrobotics.lib.mathematics.units.derived.LinearAcceleration
 import org.ghrobotics.lib.mathematics.units.derived.LinearVelocity
@@ -50,5 +51,17 @@ class FalconTrajectoryConfig(
      */
     fun setEndVelocity(endVelocity: SIUnit<LinearVelocity>) {
         super.setEndVelocity(endVelocity.value)
+    }
+
+    override fun addConstraint(constraint: TrajectoryConstraint): FalconTrajectoryConfig = also {
+        super.addConstraint(constraint)
+    }
+
+    override fun addConstraints(constraints: List<TrajectoryConstraint>): FalconTrajectoryConfig = also {
+        super.addConstraints(constraints)
+    }
+
+    fun addConstraints(vararg constraints: TrajectoryConstraint): FalconTrajectoryConfig = also {
+        super.addConstraints(constraints.asList())
     }
 }

--- a/core/src/main/kotlin/org/ghrobotics/lib/mathematics/twodim/trajectory/FalconTrajectoryConfig.kt
+++ b/core/src/main/kotlin/org/ghrobotics/lib/mathematics/twodim/trajectory/FalconTrajectoryConfig.kt
@@ -41,7 +41,7 @@ class FalconTrajectoryConfig(
      * Set the starting velocity of the trajectory.
      * @param startVelocity The start velocity of the trajectory.
      */
-    fun setStartVelocity(startVelocity: SIUnit<LinearVelocity>) {
+    fun setStartVelocity(startVelocity: SIUnit<LinearVelocity>): FalconTrajectoryConfig = also {
         super.setStartVelocity(startVelocity.value)
     }
 
@@ -49,7 +49,7 @@ class FalconTrajectoryConfig(
      * Set the ending velocity of the trajectory.
      * @param endVelocity The ending velocity of the trajectory.
      */
-    fun setEndVelocity(endVelocity: SIUnit<LinearVelocity>) {
+    fun setEndVelocity(endVelocity: SIUnit<LinearVelocity>): FalconTrajectoryConfig = also {
         super.setEndVelocity(endVelocity.value)
     }
 

--- a/core/src/test/kotlin/org/ghrobotics/lib/mathematics/twodim/trajectory/PathFinderTest.kt
+++ b/core/src/test/kotlin/org/ghrobotics/lib/mathematics/twodim/trajectory/PathFinderTest.kt
@@ -53,9 +53,9 @@ class PathFinderTest {
         }
         println("Generated Nodes in $nodeCreationTime ms")
         lateinit var trajectory: Trajectory
-        val config = FalconTrajectoryConfig(10.feet.velocity, 4.feet.acceleration).apply {
-            addConstraint(CentripetalAccelerationConstraint(4.0))
-        }
+        val config = FalconTrajectoryConfig(10.feet.velocity, 4.feet.acceleration)
+            .addConstraint(CentripetalAccelerationConstraint(4.0))
+
         val trajectoryTime = measureTimeMillis {
             trajectory = FalconTrajectoryGenerator.generateTrajectory(
                 path,


### PR DESCRIPTION
Just a small change to reflect the internal WPILib behavior. Because FalconTrajectoryGenerator's generate method needs a FalconTrajectoryConfig, we need to override the add constraint calls to return a FalconTrajectoryConfig. This commit addresses that.