### PR TITLE
Add protected modifier to FalconWCD motors

### DIFF
--- a/wpi/src/main/kotlin/org/ghrobotics/lib/subsystems/drive/CharacterizationCommand.kt
+++ b/wpi/src/main/kotlin/org/ghrobotics/lib/subsystems/drive/CharacterizationCommand.kt
@@ -37,12 +37,12 @@ class CharacterizationCommand(private val drivetrain: FalconWestCoastDrivetrain)
         numberArray[0] = Timer.getFPGATimestamp()
         numberArray[1] = RobotController.getBatteryVoltage()
         numberArray[2] = autospeed
-        numberArray[3] = drivetrain.leftMotor.voltageOutput.value
-        numberArray[4] = drivetrain.rightMotor.voltageOutput.value
-        numberArray[5] = drivetrain.leftMotor.encoder.position.value
-        numberArray[6] = drivetrain.rightMotor.encoder.position.value
-        numberArray[7] = drivetrain.leftMotor.encoder.velocity.value
-        numberArray[8] = drivetrain.rightMotor.encoder.velocity.value
+        numberArray[3] = drivetrain.leftVoltage.value
+        numberArray[4] = drivetrain.rightVoltage.value
+        numberArray[5] = drivetrain.leftPosition.value
+        numberArray[6] = drivetrain.rightPosition.value
+        numberArray[7] = drivetrain.leftVelocity.value
+        numberArray[8] = drivetrain.rightVelocity.value
 
         telemetryEntry.setNumberArray(numberArray.toTypedArray())
     }

--- a/wpi/src/main/kotlin/org/ghrobotics/lib/subsystems/drive/FalconWestCoastDrivetrain.kt
+++ b/wpi/src/main/kotlin/org/ghrobotics/lib/subsystems/drive/FalconWestCoastDrivetrain.kt
@@ -87,6 +87,36 @@ abstract class FalconWestCoastDrivetrain : TrajectoryTrackerDriveBase(), Emergen
     override var robotPosition: Pose2d = Pose2d()
 
     /**
+     * Returns the voltage output of the left motor.
+     */
+    val leftVoltage get() = periodicIO.leftVoltage
+
+    /**
+     * Returns the voltage output of the right motor.
+     */
+    val rightVoltage get() = periodicIO.rightVoltage
+
+    /**
+     * Returns the position of the left side of the drivetrain.
+     */
+    val leftPosition get() = periodicIO.leftPosition
+
+    /**
+     * Returns the position of the right side of the drivetrain.
+     */
+    val rightPosition get() = periodicIO.rightPosition
+
+    /**
+     * Returns the velocity of the left side of the drivetrain.
+     */
+    val leftVelocity get() = periodicIO.leftVelocity
+
+    /**
+     * Returns the velocity of the right side of the drivetrain.
+     */
+    val rightVelocity get() = periodicIO.rightVelocity
+
+    /**
      * Periodic function -- runs every 20 ms.
      */
     override fun periodic() {

--- a/wpi/src/main/kotlin/org/ghrobotics/lib/subsystems/drive/FalconWestCoastDrivetrain.kt
+++ b/wpi/src/main/kotlin/org/ghrobotics/lib/subsystems/drive/FalconWestCoastDrivetrain.kt
@@ -59,12 +59,12 @@ abstract class FalconWestCoastDrivetrain : TrajectoryTrackerDriveBase(), Emergen
     /**
      * The left motor
      */
-    abstract val leftMotor: FalconMotor<Meter>
+    protected abstract val leftMotor: FalconMotor<Meter>
 
     /**
      * The right motor
      */
-    abstract val rightMotor: FalconMotor<Meter>
+    protected abstract val rightMotor: FalconMotor<Meter>
 
     /**
      * The characterization for the left gearbox.


### PR DESCRIPTION
The motor objects should not be directly accessible from outside of the subsystem. Instead, teams should write set methods in their drive subsystem and call these from commands.