### PR TITLE
[WIP] Add simulation support to FalconEncoder and FalconMotor.

### DIFF
--- a/vendorCTRE/src/main/kotlin/org/ghrobotics/lib/motors/ctre/FalconCTRE.kt
+++ b/vendorCTRE/src/main/kotlin/org/ghrobotics/lib/motors/ctre/FalconCTRE.kt
@@ -40,8 +40,9 @@ import org.ghrobotics.lib.motors.FalconMotor
  */
 abstract class FalconCTRE<K : SIKey>(
     val motorController: IMotorController,
-    private val model: NativeUnitModel<K>
-) : AbstractFalconMotor<K>() {
+    private val model: NativeUnitModel<K>,
+    simName: String = "FalconCTRE[${motorController.deviceID}]"
+) : AbstractFalconMotor<K>(simName) {
 
     /**
      * The previous demand.

--- a/vendorCTRE/src/main/kotlin/org/ghrobotics/lib/motors/ctre/FalconCTREEncoder.kt
+++ b/vendorCTRE/src/main/kotlin/org/ghrobotics/lib/motors/ctre/FalconCTREEncoder.kt
@@ -31,7 +31,7 @@ class FalconCTREEncoder<K : SIKey>(
     private val motorController: IMotorController,
     private val pidIdx: Int = 0,
     model: NativeUnitModel<K>
-) : AbstractFalconEncoder<K>(model) {
+) : AbstractFalconEncoder<K>(model, "FalconCTREEncoder[${motorController.deviceID}]") {
     /**
      * Returns the raw velocity from the encoder.
      */

--- a/vendorCTRE/src/main/kotlin/org/ghrobotics/lib/motors/ctre/FalconFX.kt
+++ b/vendorCTRE/src/main/kotlin/org/ghrobotics/lib/motors/ctre/FalconFX.kt
@@ -31,7 +31,7 @@ import org.ghrobotics.lib.mathematics.units.nativeunit.NativeUnitModel
 class FalconFX<K : SIKey>(
     @Suppress("MemberVisibilityCanBePrivate") val talonFX: TalonFX,
     model: NativeUnitModel<K>
-) : FalconCTRE<K>(talonFX, model) {
+) : FalconCTRE<K>(talonFX, model, "FalconFX[${talonFX.deviceID}]") {
 
     /**
      * Alternate constructor where users can supply ID and native unit model.

--- a/vendorCTRE/src/main/kotlin/org/ghrobotics/lib/motors/ctre/FalconSPX.kt
+++ b/vendorCTRE/src/main/kotlin/org/ghrobotics/lib/motors/ctre/FalconSPX.kt
@@ -25,7 +25,7 @@ import org.ghrobotics.lib.mathematics.units.nativeunit.NativeUnitModel
 class FalconSPX<K : SIKey>(
     @Suppress("MemberVisibilityCanBePrivate") val victorSPX: VictorSPX,
     model: NativeUnitModel<K>
-) : FalconCTRE<K>(victorSPX, model) {
+) : FalconCTRE<K>(victorSPX, model, "FalconSPX[${victorSPX.deviceID}]") {
 
     /**
      * Alternate constructor where users can supply ID and native unit model.

--- a/vendorCTRE/src/main/kotlin/org/ghrobotics/lib/motors/ctre/FalconSRX.kt
+++ b/vendorCTRE/src/main/kotlin/org/ghrobotics/lib/motors/ctre/FalconSRX.kt
@@ -31,7 +31,7 @@ import org.ghrobotics.lib.mathematics.units.nativeunit.NativeUnitModel
 class FalconSRX<K : SIKey>(
     @Suppress("MemberVisibilityCanBePrivate") val talonSRX: TalonSRX,
     model: NativeUnitModel<K>
-) : FalconCTRE<K>(talonSRX, model) {
+) : FalconCTRE<K>(talonSRX, model, "FalconCTRE[${talonSRX.deviceID}]") {
 
     /**
      * Alternate constructor where users can supply ID and native unit model.

--- a/vendorPWF/src/main/kotlin/org/ghrobotics/lib/motors/pwf/FalconVenom.kt
+++ b/vendorPWF/src/main/kotlin/org/ghrobotics/lib/motors/pwf/FalconVenom.kt
@@ -23,6 +23,12 @@ import org.ghrobotics.lib.mathematics.units.nativeunit.NativeUnitModel
 import org.ghrobotics.lib.motors.AbstractFalconMotor
 import org.ghrobotics.lib.motors.FalconMotor
 
+internal fun getVenomID(venom: CANVenom): Int {
+    val field = venom.javaClass.getDeclaredField("m_motorID")
+    field.isAccessible = true
+    return field.getInt(venom)
+}
+
 /**
  * Wrapper around the Venom motor controller.
  *
@@ -32,7 +38,7 @@ import org.ghrobotics.lib.motors.FalconMotor
 class FalconVenom<K : SIKey>(
     @Suppress("MemberVisibilityCanBePrivate") val venom: CANVenom,
     private val model: NativeUnitModel<K>
-) : AbstractFalconMotor<K>() {
+) : AbstractFalconMotor<K>("FalconVenom[${getVenomID(venom)}]") {
 
     /**
      * Alternate constructor where users can supply ID and native unit model.

--- a/vendorPWF/src/main/kotlin/org/ghrobotics/lib/motors/pwf/FalconVenomEncoder.kt
+++ b/vendorPWF/src/main/kotlin/org/ghrobotics/lib/motors/pwf/FalconVenomEncoder.kt
@@ -22,7 +22,7 @@ import org.ghrobotics.lib.motors.AbstractFalconEncoder
 class FalconVenomEncoder<K : SIKey>(
     private val venom: CANVenom,
     model: NativeUnitModel<K>
-) : AbstractFalconEncoder<K>(model) {
+) : AbstractFalconEncoder<K>(model, "FalconVenomEncoder[${getVenomID(venom)}]") {
     /**
      * Returns the raw velocity from the encoder.
      */

--- a/vendorREV/src/main/kotlin/org/ghrobotics/lib/motors/rev/FalconMAX.kt
+++ b/vendorREV/src/main/kotlin/org/ghrobotics/lib/motors/rev/FalconMAX.kt
@@ -41,7 +41,7 @@ class FalconMAX<K : SIKey>(
     private val model: NativeUnitModel<K>,
     useAlternateEncoder: Boolean = false,
     alternateEncoderCPR: Int = 8192
-) : AbstractFalconMotor<K>() {
+) : AbstractFalconMotor<K>("FalconMAX[${canSparkMax.deviceId}]") {
 
     /**
      * Creates a Spark MAX motor controller. The alternate encoder CPR is defaulted

--- a/vendorREV/src/main/kotlin/org/ghrobotics/lib/motors/rev/FalconMAXEncoder.kt
+++ b/vendorREV/src/main/kotlin/org/ghrobotics/lib/motors/rev/FalconMAXEncoder.kt
@@ -16,6 +16,12 @@ import org.ghrobotics.lib.mathematics.units.nativeunit.NativeUnitModel
 import org.ghrobotics.lib.mathematics.units.nativeunit.NativeUnitVelocity
 import org.ghrobotics.lib.motors.AbstractFalconEncoder
 
+fun getCanEncoderID(canEncoder: CANEncoder): Int {
+    val method = canEncoder.javaClass.getDeclaredMethod("getID")
+    method.isAccessible = true
+    return method.invoke(canEncoder) as Int
+}
+
 /**
  * Represents an encoder connected to a Spark MAX.
  *
@@ -25,7 +31,7 @@ import org.ghrobotics.lib.motors.AbstractFalconEncoder
 class FalconMAXEncoder<K : SIKey>(
     val canEncoder: CANEncoder,
     model: NativeUnitModel<K>
-) : AbstractFalconEncoder<K>(model) {
+) : AbstractFalconEncoder<K>(model, "FalconMAXEncoder[${getCanEncoderID(canEncoder)}]") {
     /**
      * Returns the raw velocity from the encoder.
      */

--- a/wpi/src/main/kotlin/org/ghrobotics/lib/motors/AbstractFalconEncoder.kt
+++ b/wpi/src/main/kotlin/org/ghrobotics/lib/motors/AbstractFalconEncoder.kt
@@ -8,16 +8,36 @@
 
 package org.ghrobotics.lib.motors
 
+import edu.wpi.first.hal.SimDevice
+import edu.wpi.first.hal.SimDouble
 import org.ghrobotics.lib.mathematics.units.SIKey
 import org.ghrobotics.lib.mathematics.units.SIUnit
 import org.ghrobotics.lib.mathematics.units.derived.Velocity
 import org.ghrobotics.lib.mathematics.units.nativeunit.NativeUnitModel
 
 abstract class AbstractFalconEncoder<K : SIKey>(
-    val model: NativeUnitModel<K>
+    val model: NativeUnitModel<K>,
+    simName: String
 ) : FalconEncoder<K> {
-    override val position: SIUnit<K> get() = model.fromNativeUnitPosition(rawPosition)
-    override val velocity: SIUnit<Velocity<K>> get() = model.fromNativeUnitVelocity(rawVelocity)
+
+    private val simDevice: SimDevice? = SimDevice.create(simName)
+    private val simPositionHandle: SimDouble? = simDevice?.createDouble("Position", false, 0.0)
+    private val simVelocityHandle: SimDouble? = simDevice?.createDouble("Position", false, 0.0)
+
+    override fun setSimulatedPosition(position: SIUnit<K>) {
+        simPositionHandle?.set(position.value)
+    }
+
+    override fun setSimulatedVelocity(position: SIUnit<K>) {
+        simVelocityHandle?.set(position.value)
+    }
+
+    override val position: SIUnit<K>
+        get() = if (simPositionHandle != null) SIUnit(simPositionHandle.get())
+        else model.fromNativeUnitPosition(rawPosition)
+    override val velocity: SIUnit<Velocity<K>>
+        get() = if (simVelocityHandle != null) SIUnit(simVelocityHandle.get())
+        else model.fromNativeUnitVelocity(rawVelocity)
 
     override fun resetPosition(newPosition: SIUnit<K>) {
         resetPositionRaw(model.toNativeUnitPosition(newPosition))

--- a/wpi/src/main/kotlin/org/ghrobotics/lib/motors/AbstractFalconMotor.kt
+++ b/wpi/src/main/kotlin/org/ghrobotics/lib/motors/AbstractFalconMotor.kt
@@ -8,9 +8,12 @@
 
 package org.ghrobotics.lib.motors
 
+import edu.wpi.first.hal.SimDevice
 import org.ghrobotics.lib.mathematics.units.SIKey
 
-abstract class AbstractFalconMotor<K : SIKey> : FalconMotor<K> {
+abstract class AbstractFalconMotor<K : SIKey>(simName: String) : FalconMotor<K> {
+
+    private val simDevice: SimDevice? = SimDevice.create(simName)
 
     override var useMotionProfileForPosition: Boolean = false
 

--- a/wpi/src/main/kotlin/org/ghrobotics/lib/motors/FalconEncoder.kt
+++ b/wpi/src/main/kotlin/org/ghrobotics/lib/motors/FalconEncoder.kt
@@ -17,11 +17,21 @@ import org.ghrobotics.lib.mathematics.units.nativeunit.NativeUnitVelocity
 interface FalconEncoder<K : SIKey> {
 
     /**
-     * The velocity of the encoder in [K]/s
+     * Sets the simulated [position] of this motor.
+     */
+    fun setSimulatedPosition(position: SIUnit<K>)
+
+    /**
+     * Sets the simulated [velocity] of this motor.
+     */
+    fun setSimulatedVelocity(position: SIUnit<K>)
+
+    /**
+     * The velocity of the encoder in [K]/s. When in a simulation, returns the simulated velocity.
      */
     val velocity: SIUnit<Velocity<K>>
     /**
-     * The position of the encoder in [K]
+     * The position of the encoder in [K]. When in a simulation, returns the simulated position.
      */
     val position: SIUnit<K>
 
@@ -34,6 +44,9 @@ interface FalconEncoder<K : SIKey> {
      */
     val rawPosition: SIUnit<NativeUnit>
 
+    /**
+     * Reset the position of the encoder. Does not work in a simulation.
+     */
     fun resetPosition(newPosition: SIUnit<K>)
 
     fun resetPositionRaw(newPosition: SIUnit<NativeUnit>)


### PR DESCRIPTION
This adds support for simulating the position, velocity and voltage outputs of FalconEncoder and FalconMotor. The sim device name is customized by each of their subclasses.

- [ ] Sim position support
- [ ] Sim velocity support
- [ ] Sim voltage support