### PR TITLE
Null check the bottom bound in time pose buffer

### DIFF
--- a/wpi/src/main/kotlin/org/ghrobotics/lib/localization/TimePoseInterpolatableBuffer.kt
+++ b/wpi/src/main/kotlin/org/ghrobotics/lib/localization/TimePoseInterpolatableBuffer.kt
@@ -57,7 +57,7 @@ class TimePoseInterpolatableBuffer(
         val bottomBound = bufferMap.floorEntry(time)
 
         return when {
-            topBound == null -> bottomBound.value
+            topBound == null -> bottomBound?.value
             bottomBound == null -> topBound.value
             else -> bottomBound.value.interpolate(
                 topBound.value,


### PR DESCRIPTION
We don't need to check that the top bound is non-null on L61 b/c we already know from L60 that its non-null